### PR TITLE
Fix bug with stat not erroring when given nonexisant file

### DIFF
--- a/pfs/commands/readcmd.go
+++ b/pfs/commands/readcmd.go
@@ -17,6 +17,7 @@ func ReadCommand(args []string) {
 	directory := args[0]
 	verboseLog("read : given directory = " + directory)
 	fileNameBytes, err := ioutil.ReadFile(path.Join(directory, "names", args[1]))
+	checkErr("read", err)
 	fileName := string(fileNameBytes)
 	file, err := os.Open(path.Join(directory, "contents", fileName))
 	checkErr("read", err)

--- a/pfs/commands/statcmd.go
+++ b/pfs/commands/statcmd.go
@@ -26,6 +26,7 @@ func StatCommand(args []string) {
 	directory := args[0]
 	verboseLog("stat : given directory = " + directory)
 	fileNameBytes, err := ioutil.ReadFile(path.Join(directory, "names", args[1]))
+	checkErr("stat", err)
 	fileName := string(fileNameBytes)
 	file, err := os.Open(path.Join(directory, "contents", fileName))
 	checkErr("stat", err)


### PR DESCRIPTION
Relates to a bug reported on #27 
