### PR TITLE
Remove bad pattern of not checking error directly after it is created

### DIFF
--- a/pfs/commands/writecmd.go
+++ b/pfs/commands/writecmd.go
@@ -16,9 +16,9 @@ func WriteCommand(args []string) {
 	directory := args[0]
 	verboseLog("write : given directory = " + directory)
 	fileNameBytes, err := ioutil.ReadFile(path.Join(directory, "names", args[1]))
+	checkErr("write", err)
 	fileName := string(fileNameBytes)
 	verboseLog("write : wrting to " + fileName)
-	checkErr("write", err)
 	fileData, err := ioutil.ReadAll(os.Stdin)
 	checkErr("write", err)
 	if len(args) == 2 {


### PR DESCRIPTION
In write command, this was found because of an error in stat. 
