### PR TITLE
Fixes for write command when given offset and length paramaters

### DIFF
--- a/pfs/commands/writecmd.go
+++ b/pfs/commands/writecmd.go
@@ -31,6 +31,19 @@ func WriteCommand(args []string) {
 		checkErr("write", err)
 		offset, err := strconv.Atoi(args[2])
 		checkErr("write", err)
+		if len(args) == 3 {
+			err = contentsFile.Truncate(int64(offset))
+			checkErr("write", err)
+		} else {
+			length, err := strconv.Atoi(args[3])
+			checkErr("write", err)
+			if len(fileData) > length {
+				fileData = fileData[:length]
+			} else if len(fileData) < length {
+				emptyBytes := make([]byte, length-len(fileData))
+				fileData = append(fileData, emptyBytes...)
+			}
+		}
 		_, err = contentsFile.WriteAt(fileData, int64(offset))
 		checkErr("write", err)
 	}


### PR DESCRIPTION
When only given an offset but not a length, it should truncate the file and then write the bytes from stdin. Otherwise it should overwrite exactly length bytes from offset. 
