### PR TITLE
Better pfs/pfi logging

### DIFF
--- a/paranoid-cli/commands/mountcmd.go
+++ b/paranoid-cli/commands/mountcmd.go
@@ -52,19 +52,21 @@ func Mount(c *cli.Context) {
 	}
 
 	cmd = exec.Command("pfs-network-client", "--client", directory, splits[0], splits[1])
-	outfile1, err := os.Create("./out1.txt")
 	if err != nil {
 		log.Fatalln("FATAL error creating output file")
 	}
-	cmd.Stderr = outfile1
 	err = cmd.Start()
 
 	cmd = exec.Command("pfi", directory, args[2])
-	outfile2, err := os.Create("./out2.txt")
+	if c.Bool("verbose") {
+		cmd = exec.Command("pfi", "-v", directory, args[2])
+	}
+	outfile, err := os.Create(path.Join(directory, "meta", "logs", "pfiLog.txt"))
+
 	if err != nil {
 		log.Fatalln("FATAL error creating output file")
 	}
-	cmd.Stderr = outfile2
+	cmd.Stderr = outfile
 	err = cmd.Start()
 	if err != nil {
 		log.Fatalln("FATAL error running pfi command : ", err)

--- a/pfi/pfsminterface/runcommand.go
+++ b/pfi/pfsminterface/runcommand.go
@@ -1,6 +1,7 @@
 package pfsminterface
 
 import (
+	"github.com/cpssd/paranoid/pfi/util"
 	"log"
 	"os"
 	"os/exec"
@@ -12,6 +13,9 @@ var OriginFlag string
 //RunCommand runs a pfs command with the given arguments. Gives stdinData on stdIn to pfs if it is not nil.
 func RunCommand(stdinData []byte, cmdArgs ...string) (int, []byte) {
 	cmdArgs = append(cmdArgs, OriginFlag)
+	if util.LogOutput {
+		cmdArgs = append(cmdArgs, "-v")
+	}
 	command := exec.Command("pfsm", cmdArgs...)
 	command.Stderr = os.Stderr
 

--- a/pfsm/commands/flags.go
+++ b/pfsm/commands/flags.go
@@ -27,7 +27,7 @@ func ProcessFlags(toFlags []string) {
 			Flags.Network = true
 		} else if strings.ToLower(toFlags[i]) == "--version" {
 			Flags.Version = true
-		} else if strings.ToLower(toFlags[i]) == "--verbose" {
+		} else if strings.ToLower(toFlags[i]) == "--verbose" || strings.ToLower(toFlags[i]) == "-v" {
 			Flags.Verbose = true
 		}
 	}

--- a/pfsm/commands/initcmd.go
+++ b/pfsm/commands/initcmd.go
@@ -40,6 +40,7 @@ func InitCommand(args []string) {
 	makeDir(directory, "names")
 	makeDir(directory, "inodes")
 	metaDir := makeDir(directory, "meta")
+	makeDir(metaDir, "logs")
 	makeDir(directory, "contents")
 	uuid, err := ioutil.ReadFile("/proc/sys/kernel/random/uuid")
 	uuidString := strings.TrimSpace(string(uuid))


### PR DESCRIPTION
Move the logging from out1.txt and out2.txt to a file in [paranoidDirectory]/meta/logs/
Pass -verbose argument from paranoid-cli to pfi to pfs.
