### PR TITLE
Fix the pfsd integration test

### DIFF
--- a/pfsd/integration_test.go
+++ b/pfsd/integration_test.go
@@ -23,7 +23,7 @@ func TestMain(m *testing.M) {
 	// Make sure we start with an empty directory
 	os.RemoveAll(tmpdir)
 	os.Mkdir(tmpdir, 0777)
-	init := exec.Command("paranoid-cli", "init", tmpdir)
+	init := exec.Command("pfsm", "init", tmpdir)
 	init.Run()
 	pnetserver.ParanoidDir = tmpdir
 	globals.Port = 10101


### PR DESCRIPTION
paranoid-cli now takes a file system name, not a directory for usability. 
