### PR TITLE
Don't decode Base64 in ICserver

### DIFF
--- a/pfsd/icserver/icserver.go
+++ b/pfsd/icserver/icserver.go
@@ -2,7 +2,6 @@ package icserver
 
 import (
 	"bytes"
-	"encoding/base64"
 	"encoding/json"
 	"log"
 	"net"
@@ -18,10 +17,9 @@ var verbose = false
 
 // FileSystemMessage is the structure which represents messages coming from the client
 type FileSystemMessage struct {
-	Command    string   `json:"command"`
-	Args       []string `json:"args"`
-	Base64Data string   `json:"data"`
-	Data       []byte
+	Command string   `json:"command"`
+	Args    []string `json:"args"`
+	Data    []byte   `json:"data"`
 }
 
 // handleConnection accepts a connection and handles messages received through the connection
@@ -60,13 +58,6 @@ func handleConnection(conn net.Conn) {
 				}
 			}
 			if endOfMessage {
-				if len(message.Base64Data) != 0 {
-					message.Data, err = base64.StdEncoding.DecodeString(message.Base64Data)
-					if err != nil {
-						log.Fatalln("icserver base64 decoding error: ", err)
-					}
-				}
-
 				MessageChan <- *message
 				verboseLog("icserver new message pushed to channel: " + message.Command)
 			}

--- a/pfsm/icclient/icclient.go
+++ b/pfsm/icclient/icclient.go
@@ -12,7 +12,7 @@ import (
 type fileSystemMessage struct {
 	Command string   `json:"command"`
 	Args    []string `json:"args"`
-	Data    string   `json:"data"`
+	Data    []byte   `json:"data"`
 }
 
 // SendMessage sends a message to the server
@@ -20,7 +20,7 @@ func SendMessage(pfsDirectory string, command string, arguments []string) {
 	message := fileSystemMessage{
 		Command: command,
 		Args:    arguments,
-		Data:    "",
+		Data:    []byte(""),
 	}
 
 	dialAndSend(pfsDirectory, message)
@@ -33,7 +33,7 @@ func SendMessageWithData(pfsDirectory string, command string, arguments []string
 	message := fileSystemMessage{
 		Command: command,
 		Args:    arguments,
-		Data:    base64Data,
+		Data:    []byte(base64Data),
 	}
 
 	dialAndSend(pfsDirectory, message)


### PR DESCRIPTION
The ic server should not decode the Base64 data, as then the pfsd client would have to reencode it. 
