### PR TITLE
Better error message for paranoid-cli mount. 

### DIFF
--- a/paranoid-cli/commands/mountcmd.go
+++ b/paranoid-cli/commands/mountcmd.go
@@ -40,6 +40,9 @@ func doMount(c *cli.Context, args []string) {
 	}
 	pfsDir := path.Join(usr.HomeDir, ".pfs", args[1])
 
+	if _, err := os.Stat(pfsDir); os.IsNotExist(err) {
+		log.Fatalln("FATAL : PFS directory does not exist")
+	}
 	if _, err := os.Stat(path.Join(pfsDir, "contents")); os.IsNotExist(err) {
 		log.Fatalln("FATAL : PFS directory does not include contents directory")
 	}


### PR DESCRIPTION
Gives a confusing error message when the pfs is not existent. 
