### PR TITLE
Fixed two bugs in dnetserver/join.go

### DIFF
--- a/discovery-server/dnetserver/join.go
+++ b/discovery-server/dnetserver/join.go
@@ -45,9 +45,9 @@ func (s *DiscoveryServer) Join(ctx context.Context, req *pb.JoinRequest) (*pb.Jo
 
 func getNodes(pool string) []*pb.Node {
 	var nodes []*pb.Node
-	for _, node := range Nodes {
-		if node.Pool == pool {
-			nodes = append(nodes, &node.Data)
+	for i := 0; i < len(Nodes); i++ {
+		if Nodes[i].Active && Nodes[i].Pool == pool {
+			nodes = append(nodes, &(Nodes[i].Data))
 		}
 	}
 	return nodes


### PR DESCRIPTION
First bug was that the server didn't check if a node was active before returning it in a `JoinResponse`.

Second bug was a case of using a pointer to a value returned by `range`. This is a mistake because `range` copies values; it does not reference them. Because of this the list of returned nodes only contained the last node several times.

Closes #219 
