### PR TITLE
Fix pfsm verbose log

### DIFF
--- a/pfi/main.go
+++ b/pfi/main.go
@@ -20,6 +20,7 @@ func main() {
 
 	// Create a logger
 	util.Log, _ = logger.New("pfi", "pfi", "/dev/null")
+	util.LogOutput = *logOutput
 	if *logOutput {
 		util.Log.SetLogLevel(logger.VERBOSE)
 	}

--- a/pfsm/main.go
+++ b/pfsm/main.go
@@ -42,7 +42,7 @@ func main() {
 			for i := 1; i < len(args); i++ {
 				givenCmd = givenCmd + " " + args[i]
 			}
-			log.Println("Given command : ", givenCmd)
+			commands.Log.Verbose("Given command :", givenCmd)
 		}
 	}
 	if len(onlyArgs) > 0 {


### PR DESCRIPTION
Pfi was no longer correctly passing the verbose log parameter to pfsm. 
