### PR TITLE
Removing a Symlink

### DIFF
--- a/pfsm/commands/creatcmd.go
+++ b/pfsm/commands/creatcmd.go
@@ -10,11 +10,6 @@ import (
 	"strconv"
 )
 
-type inode struct {
-	Count int    `json:"count"`
-	Inode string `json:"inode"`
-}
-
 //CreatCommand creates a new file with the name args[1] in the pfs directory args[0]
 func CreatCommand(args []string) {
 	Log.Info("creat command called")

--- a/pfsm/commands/readlinkcmd.go
+++ b/pfsm/commands/readlinkcmd.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"encoding/json"
 	"github.com/cpssd/paranoid/pfsm/returncodes"
 	"io"
 	"io/ioutil"
@@ -32,11 +33,18 @@ func ReadlinkCommand(args []string) {
 
 	inodePath := path.Join(directory, "inodes", string(linkInode))
 
-	linkOriginBytes, err := ioutil.ReadFile(inodePath)
+	inodeContents, err := ioutil.ReadFile(inodePath)
 	if err != nil {
 		Log.Fatal("error reading link:", err)
 	}
 
+	inodeData := &inode{}
+	Log.Verbose("unlink unmarshaling ", string(inodeContents))
+	err = json.Unmarshal(inodeContents, &inodeData)
+	if err != nil {
+		Log.Fatal("error unmarshaling json ", err)
+	}
+
 	io.WriteString(os.Stdout, returncodes.GetReturnCode(returncodes.OK))
-	io.WriteString(os.Stdout, string(linkOriginBytes))
+	io.WriteString(os.Stdout, string(inodeData.Link))
 }

--- a/pfsm/commands/symlinkcmd.go
+++ b/pfsm/commands/symlinkcmd.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"encoding/json"
 	"github.com/cpssd/paranoid/pfsm/returncodes"
 	"io"
 	"io/ioutil"
@@ -44,7 +45,17 @@ func SymlinkCommand(args []string) {
 		Log.Fatal("error creating symlink:", err)
 	}
 
-	err = ioutil.WriteFile(path.Join(directory, "inodes", uuidString), []byte(args[1]), 0600)
+	nodeData := &inode{
+		Inode: uuidString,
+		Count: 1,
+		Link:  args[1],
+	}
+	jsonData, err := json.Marshal(nodeData)
+	if err != nil {
+		Log.Fatal("error marshalling json:", err)
+	}
+
+	err = ioutil.WriteFile(path.Join(directory, "inodes", uuidString), jsonData, 0600)
 
 	// Send to the server if not coming from the network
 	if !Flags.Network {

--- a/pfsm/commands/util.go
+++ b/pfsm/commands/util.go
@@ -14,6 +14,12 @@ import (
 
 var Log *logger.ParanoidLogger
 
+type inode struct {
+	Count int    `json:"count"`
+	Inode string `json:"inode"`
+	Link  string `json:"link,omitempty"`
+}
+
 func getAccessMode(flags uint32) uint32 {
 	switch flags {
 	case syscall.O_RDONLY:


### PR DESCRIPTION
Removing symlinks was impossible before due to a bug with unlink. Fixed now

Relates to #240 
