### PR TITLE
Fixed logging errors in discovery server.

### DIFF
--- a/discovery-server/dnetserver/disconnect.go
+++ b/discovery-server/dnetserver/disconnect.go
@@ -12,12 +12,12 @@ func (s *DiscoveryServer) Disconnect(ctx context.Context, req *pb.DisconnectRequ
 	for i, node := range Nodes {
 		if node.Data == *req.Node {
 			Nodes[i].Active = false
-			Log.Info("Disconnect: Node %s disconnected", req.Node)
+			Log.Info("Disconnect: Node %s:%s disconnected", req.Node.Ip, req.Node.Port)
 			return &pb.EmptyMessage{}, nil
 		}
 	}
 
-	Log.Errorf("Disconnect: Node %s was not found", req.Node)
+	Log.Errorf("Disconnect: Node %s:%s was not found", req.Node.Ip, req.Node.Port)
 	returnError := grpc.Errorf(codes.NotFound, "node was not found")
 	return &pb.EmptyMessage{}, returnError
 }

--- a/discovery-server/dnetserver/join.go
+++ b/discovery-server/dnetserver/join.go
@@ -17,7 +17,7 @@ func (s *DiscoveryServer) Join(ctx context.Context, req *pb.JoinRequest) (*pb.Jo
 	for _, node := range Nodes {
 		if node.Data == *req.Node {
 			if node.Active {
-				Log.Errorf("Join: node %s is already part of the cluster", req.Node)
+				Log.Errorf("Join: node %s:%s is already part of the cluster", req.Node.Ip, req.Node.Port)
 				returnError := grpc.Errorf(codes.AlreadyExists,
 					"node is already part of the cluster")
 				return &pb.JoinResponse{}, returnError
@@ -38,7 +38,7 @@ func (s *DiscoveryServer) Join(ctx context.Context, req *pb.JoinRequest) (*pb.Jo
 
 	newNode := Node{true, req.Pool, time.Now().Add(RenewInterval), *req.Node}
 	Nodes = append(Nodes, newNode)
-	Log.Infof("Join: Node %s joined \n", req.Node)
+	Log.Infof("Join: Node %s:%s joined \n", req.Node.Ip, req.Node.Port)
 
 	return &response, nil
 }

--- a/discovery-server/dnetserver/renew.go
+++ b/discovery-server/dnetserver/renew.go
@@ -18,7 +18,7 @@ func (s *DiscoveryServer) Renew(ctx context.Context, req *pb.JoinRequest) (*pb.E
 			if node.Active {
 				Nodes[i].ExpiryTime = time.Now().Add(RenewInterval)
 				isActiveNode = true
-				Log.Infof("Renew: Node %s renewed", req.Node)
+				Log.Infof("Renew: Node %s:%s renewed", req.Node.Ip, req.Node.Port)
 			}
 			isInNodes = true
 			break
@@ -27,11 +27,11 @@ func (s *DiscoveryServer) Renew(ctx context.Context, req *pb.JoinRequest) (*pb.E
 
 	var returnError error
 	if !isInNodes {
-		Log.Errorf("Renew: node %s not found\n", req.Node)
+		Log.Errorf("Renew: node %s:%s not found", req.Node.Ip, req.Node.Port)
 		returnError = grpc.Errorf(codes.NotFound, "node was not found")
 	}
 	if !isActiveNode {
-		Log.Error("Renew: Renewal time is past deadline for node", req.Node.Ip)
+		Log.Errorf("Renew: Renewal time is past deadline for node %s:%s", req.Node.Ip, req.Node.Port)
 		returnError = grpc.Errorf(codes.DeadlineExceeded, "renewal time is past deadline")
 	}
 	return &pb.EmptyMessage{}, returnError // returns nil if no error


### PR DESCRIPTION
The `String` method for `Node` does not apply to the protobuf versions of `Node`.
