### PR TITLE
Added flag to choose network interface.

### DIFF
--- a/paranoid-cli/commands/mountcmd.go
+++ b/paranoid-cli/commands/mountcmd.go
@@ -93,6 +93,10 @@ func doMount(c *cli.Context, args []string) {
 			if c.GlobalBool("verbose") {
 				pfsdFlags = append(pfsdFlags, "-v")
 			}
+			iface := c.String("interface")
+			if iface != "" {
+				pfsdFlags = append(pfsdFlags, "-interface="+iface)
+			}
 			cmd := exec.Command("pfsd", append(pfsdFlags, pfsdArgs...)...)
 			cmd.Stderr = outfile
 			err = cmd.Start()
@@ -117,6 +121,10 @@ func doMount(c *cli.Context, args []string) {
 			var pfsdFlags []string
 			if c.GlobalBool("verbose") {
 				pfsdFlags = append(pfsdFlags, "-v")
+			}
+			iface := c.String("interface")
+			if iface != "" {
+				pfsdFlags = append(pfsdFlags, "-interface="+iface)
 			}
 			cmd := exec.Command("pfsd", append(pfsdFlags, pfsdArgs...)...)
 			cmd.Stderr = outfile

--- a/paranoid-cli/main.go
+++ b/paranoid-cli/main.go
@@ -66,6 +66,10 @@ func main() {
 					Name:  "n, noprompt",
 					Usage: "disable the prompt when attempting to mount a PFS without TLS/SSL",
 				},
+				cli.StringFlag{
+					Name:  "i, interface",
+					Usage: "name a network interface over which to make connections. Defaults to default interface",
+				},
 			},
 		},
 		{
@@ -103,6 +107,10 @@ func main() {
 				cli.BoolFlag{
 					Name:  "n, noprompt",
 					Usage: "disable the prompt when attempting to mount a PFS without TLS/SSL",
+				},
+				cli.StringFlag{
+					Name:  "i, interface",
+					Usage: "name a network interface over which to make connections. Defaults to default interface",
 				},
 			},
 		},

--- a/pfsd/main.go
+++ b/pfsd/main.go
@@ -25,10 +25,10 @@ var (
 
 	certFile   = flag.String("cert", "", "TLS certificate file - if empty connection will be unencrypted")
 	keyFile    = flag.String("key", "", "TLS key file - if empty connection will be unencrypted")
+	noNetwork  = flag.Bool("no_networking", false, "Do not perform any networking")
 	skipVerify = flag.Bool("skip_verification", false,
 		"skip verification of TLS certificate chain and hostname - not recommended unless using self-signed certs")
-	noNetwork = flag.Bool("no_networking", false, "Do not perform any networking")
-	verbose   = flag.Bool("v", false, "Use verbose logging")
+	verbose = flag.Bool("v", false, "Use verbose logging")
 )
 
 func startRPCServer(lis *net.Listener) {
@@ -80,8 +80,12 @@ func main() {
 	if !*noNetwork {
 		pnetserver.ParanoidDir = flag.Arg(0)
 
+		ip, err := upnp.GetIP()
+		if err != nil {
+			log.Fatalln("FATAL: Could not get IP:", err)
+		}
 		//Asking for port 0 requests a random free port from the OS.
-		lis, err := net.Listen("tcp", ":0")
+		lis, err := net.Listen("tcp", ip+":0")
 		if err != nil {
 			log.Fatalf("FATAL: Failed to start listening : %v.\n", err)
 		}

--- a/pfsd/upnp/upnp.go
+++ b/pfsd/upnp/upnp.go
@@ -2,6 +2,7 @@ package upnp
 
 import (
 	"errors"
+	"flag"
 	"github.com/cpssd/paranoid/pfsd/globals"
 	"github.com/huin/goupnp/dcps/internetgateway1"
 	"log"
@@ -14,6 +15,9 @@ var (
 	uPnPClientsPPP      []*internetgateway1.WANPPPConnection1
 	ipPortMappedClient  *internetgateway1.WANIPConnection1
 	pppPortMappedClient *internetgateway1.WANPPPConnection1
+
+	iface = flag.String("interface", "default",
+		"network interface on which to perform connections. If not set, will use default interface.")
 )
 
 const attemptedPortAssignments = 10
@@ -123,6 +127,9 @@ func GetInternalIp() (string, error) {
 		if (i.Flags & net.FlagLoopback) != 0 {
 			continue
 		}
+		if *iface != "default" && i.Name != *iface {
+			continue
+		}
 		addrs, _ := i.Addrs()
 		for _, addr := range addrs {
 			var ip net.IP
@@ -135,7 +142,7 @@ func GetInternalIp() (string, error) {
 			return ip.String(), nil
 		}
 	}
-	return "", errors.New("No interfaces found")
+	return "", errors.New("No matching interfaces found")
 }
 
 //GetExternalIp gets the external IP of the port mapped device.


### PR DESCRIPTION
You can now supply `-i, --interface` to `paranoid-cli (auto)mount` to tell `pfsd` what network interface to use. Closes #251 
