### PR TITLE
Fixes deadlock in PFSD on SIGTERM/SIGHUP

### DIFF
--- a/pfsd/dnetclient/discovery.go
+++ b/pfsd/dnetclient/discovery.go
@@ -46,7 +46,7 @@ func JoinDiscovery(pool string) {
 			Log.Fatal("Failure dialing discovery server after multiple attempts, Giving up", err)
 		}
 	}
-	globals.Wait.Add(2)
+	globals.Wait.Add(1)
 	go pingPeers()
 }
 


### PR DESCRIPTION
Was caused by [this line](https://github.com/CPSSD/paranoid/commit/439307d970994e9d3b812078372a636b35eadabe#diff-74155d1f5e0e9b035d95d107277f8c12R31) being deleted in a future pull request but without changing the WaitGroup addition above it from 2 to 1.

Closes #286 
