### PR TITLE
Increase one leader wait time to match another

### DIFF
--- a/raft/raft.go
+++ b/raft/raft.go
@@ -245,7 +245,7 @@ func (s *RaftNetworkServer) RequestAddLogEntry(entry *pb.Entry) error {
 		count := 0
 		for {
 			count++
-			if count > 20 {
+			if count > 40 {
 				return errors.New("Could not find a leader")
 			}
 			time.Sleep(500 * time.Millisecond)


### PR DESCRIPTION
The test timed out and failed after 10 seconds, however this should have a longer time out to match the other leader election timeout. 
