### PR TITLE
Fix too many open files error

### DIFF
--- a/libpfs/commands/chmodcmd.go
+++ b/libpfs/commands/chmodcmd.go
@@ -60,6 +60,7 @@ func ChmodCommand(directory, fileName string, perms os.FileMode, sendOverNetwork
 	if err != nil {
 		return returncodes.EUNEXPECTED, fmt.Errorf("unexpected error attempting to open file:", err)
 	}
+	defer contentsFile.Close()
 
 	err = contentsFile.Chmod(perms)
 	if err != nil {

--- a/libpfs/commands/creatcmd.go
+++ b/libpfs/commands/creatcmd.go
@@ -71,6 +71,7 @@ func CreatCommand(directory, fileName string, perms os.FileMode, sendOverNetwork
 	if err != nil {
 		return returncodes.EUNEXPECTED, fmt.Errorf("error creating contents file:", err)
 	}
+	defer contentsFile.Close()
 
 	err = contentsFile.Chmod(perms)
 	if err != nil {

--- a/libpfs/commands/linkcmd.go
+++ b/libpfs/commands/linkcmd.go
@@ -98,6 +98,7 @@ func LinkCommand(directory, existingFileName, targetFileName string, sendOverNet
 	if err != nil {
 		return returncodes.EUNEXPECTED, fmt.Errorf("error opening file:", err)
 	}
+	defer openedFile.Close()
 
 	Log.Verbose("link : truncating file " + inodePath)
 	err = openedFile.Truncate(0)

--- a/libpfs/commands/mkdircmd.go
+++ b/libpfs/commands/mkdircmd.go
@@ -57,6 +57,7 @@ func MkdirCommand(directory, dirName string, mode os.FileMode, sendOverNetwork b
 	if err != nil {
 		return returncodes.EUNEXPECTED, fmt.Errorf("error creating contents file:", err)
 	}
+	defer contentsFile.Close()
 
 	err = contentsFile.Chmod(os.FileMode(mode))
 	if err != nil {
@@ -67,6 +68,7 @@ func MkdirCommand(directory, dirName string, mode os.FileMode, sendOverNetwork b
 	if err != nil {
 		return returncodes.EUNEXPECTED, fmt.Errorf("error creating info file:", err)
 	}
+	defer dirInfoFile.Close()
 
 	_, err = dirInfoFile.Write(inodeBytes)
 	if err != nil {
@@ -77,6 +79,7 @@ func MkdirCommand(directory, dirName string, mode os.FileMode, sendOverNetwork b
 	if err != nil {
 		return returncodes.EUNEXPECTED, fmt.Errorf("error creating inode file:", err)
 	}
+	defer inodeFile.Close()
 
 	nodeData := &inode{
 		Inode: inodeString,

--- a/libpfs/commands/readcmd.go
+++ b/libpfs/commands/readcmd.go
@@ -80,6 +80,7 @@ func ReadCommand(directory, fileName string, offset, length int64) (returnCode i
 	if err != nil {
 		return returncodes.EUNEXPECTED, fmt.Errorf("error opening contents file", err), nil
 	}
+	defer file.Close()
 
 	var fileBuffer bytes.Buffer
 	bytesRead := make([]byte, 1024)

--- a/libpfs/commands/truncatecmd.go
+++ b/libpfs/commands/truncatecmd.go
@@ -76,6 +76,7 @@ func TruncateCommand(directory, fileName string, length int64, sendOverNetwork b
 	if err != nil {
 		return returncodes.EUNEXPECTED, fmt.Errorf("error opening contents file:", err)
 	}
+	defer contentsFile.Close()
 
 	err = contentsFile.Truncate(length)
 	if err != nil {

--- a/libpfs/commands/utimescmd.go
+++ b/libpfs/commands/utimescmd.go
@@ -68,6 +68,7 @@ func UtimesCommand(directory, fileName string, atime, mtime *time.Time, sendOver
 	if err != nil {
 		return returncodes.EUNEXPECTED, fmt.Errorf("error opening contents file:", err)
 	}
+	defer file.Close()
 
 	fi, err := file.Stat()
 	if err != nil {

--- a/libpfs/commands/writecmd.go
+++ b/libpfs/commands/writecmd.go
@@ -78,6 +78,7 @@ func WriteCommand(directory, fileName string, offset, length int64, data []byte,
 	if err != nil {
 		return returncodes.EUNEXPECTED, fmt.Errorf("error opening contents file:", err), 0
 	}
+	defer contentsFile.Close()
 
 	if offset == -1 {
 		offset = 0


### PR DESCRIPTION
This error was exposed by the Mkdir benchmark. Mkdir fails to defer closing 3 files, which is why that specific benchmark fails, however a few other places in libpfs also forget to close opened files. 
