### PR TITLE
Internal communication between paranoid-cli and PFSD.

### DIFF
--- a/pfsd/intercom/globals.go
+++ b/pfsd/intercom/globals.go
@@ -1,0 +1,7 @@
+package intercom
+
+import (
+	"github.com/cpssd/paranoid/logger"
+)
+
+var Log *logger.ParanoidLogger

--- a/pfsd/intercom/server.go
+++ b/pfsd/intercom/server.go
@@ -1,0 +1,48 @@
+package intercom
+
+import (
+	"fmt"
+	"github.com/cpssd/paranoid/pfsd/globals"
+	"net"
+	"net/rpc"
+	"os"
+	"path"
+)
+
+var lis net.Listener
+
+type IntercomServer struct{}
+type EmptyMessage struct{}
+
+// Literally just a method for paranoid-cli to ping PFSD
+func (s *IntercomServer) ConfirmUp(req *EmptyMessage, resp *EmptyMessage) error {
+	return nil
+}
+
+func RunServer(metaDir string) {
+	socketPath := path.Join(metaDir, "intercom.sock")
+	err := os.Remove(socketPath)
+	if err != nil {
+		Log.Fatalf("Failed to remove %s: %s\n", socketPath, err)
+	}
+	server := new(IntercomServer)
+	rpc.Register(server)
+	lis, err := net.Listen("unix", socketPath)
+	if err != nil {
+		Log.Fatalf("Failed to listen on %s: %s\n", socketPath, err)
+	}
+	globals.Wait.Add(1)
+	go func() {
+		defer globals.Wait.Done()
+		Log.Info("Internal communication server listening on", socketPath)
+		rpc.Accept(lis)
+	}()
+}
+
+func ShutdownServer() error {
+	err := lis.Close()
+	if err != nil {
+		return fmt.Errorf("failed to close listener: %s", err)
+	}
+	return nil
+}

--- a/pfsd/main.go
+++ b/pfsd/main.go
@@ -6,6 +6,7 @@ import (
 	"github.com/cpssd/paranoid/logger"
 	"github.com/cpssd/paranoid/pfsd/dnetclient"
 	"github.com/cpssd/paranoid/pfsd/globals"
+	"github.com/cpssd/paranoid/pfsd/intercom"
 	"github.com/cpssd/paranoid/pfsd/keyman"
 	"github.com/cpssd/paranoid/pfsd/pfi"
 	"github.com/cpssd/paranoid/pfsd/pnetclient"
@@ -65,6 +66,7 @@ func main() {
 	pnetserver.Log = logger.New("pnetserver", "pfsd", path.Join(flag.Arg(0), "meta", "logs"))
 	upnp.Log = logger.New("upnp", "pfsd", path.Join(flag.Arg(0), "meta", "logs"))
 	keyman.Log = logger.New("keyman", "pfsd", path.Join(flag.Arg(0), "meta", "logs"))
+	intercom.Log = logger.New("intercom", "pfsd", path.Join(flag.Arg(0), "meta", "logs"))
 
 	log.SetOutput(logger.STDERR | logger.LOGFILE)
 	dnetclient.Log.SetOutput(logger.STDERR | logger.LOGFILE)
@@ -159,6 +161,7 @@ func main() {
 		globals.Wait.Add(1)
 		go UnlockWorker()
 	}
+	intercom.RunServer(path.Join(flag.Arg(0), "meta"))
 	HandleSignals()
 }
 

--- a/pfsd/signals.go
+++ b/pfsd/signals.go
@@ -3,6 +3,7 @@ package main
 import (
 	"github.com/cpssd/paranoid/pfsd/dnetclient"
 	"github.com/cpssd/paranoid/pfsd/globals"
+	"github.com/cpssd/paranoid/pfsd/intercom"
 	"github.com/cpssd/paranoid/pfsd/pnetserver"
 	"github.com/cpssd/paranoid/pfsd/upnp"
 	"github.com/kardianos/osext"
@@ -24,6 +25,12 @@ func stopAllServices() {
 	if !*noNetwork {
 		dnetclient.Disconnect() // Disconnect from the discovery server
 		srv.Stop()
+	}
+	err := intercom.ShutdownServer()
+	if err != nil {
+		log.Warn("Could not shut down internal communication server:", err)
+	} else {
+		log.Info("Internal communication server stopped.")
 	}
 	// Since srv can't talk to the waitgroup itself, we do on its behalf
 	// We also wait to give it some time to stop itself.


### PR DESCRIPTION
- Internal RPC server.
- paranoid-cli waits for PFSD to have fully started before returning.

Closes #311 
Closes #314 
