### PR TITLE
Remove duplicated information

### DIFF
--- a/pfsd/dnetclient/discovery.go
+++ b/pfsd/dnetclient/discovery.go
@@ -4,19 +4,11 @@ import (
 	"errors"
 	"github.com/cpssd/paranoid/pfsd/globals"
 	"github.com/cpssd/paranoid/pfsd/pnetclient"
-	"github.com/cpssd/paranoid/pfsd/upnp"
 	"net"
 	"time"
 )
 
-func SetDiscovery(host, port, serverPort string) {
-	ipClient, _ := upnp.GetIP()
-	globals.ThisNode = globals.Node{
-		IP:         ipClient,
-		Port:       serverPort,
-		CommonName: globals.CommonName,
-		UUID:       globals.UUID,
-	}
+func SetDiscovery(host, port string) {
 	globals.DiscoveryAddr = host + ":" + port
 
 	if globals.TLSEnabled && !globals.TLSSkipVerify {

--- a/pfsd/globals/globals.go
+++ b/pfsd/globals/globals.go
@@ -19,6 +19,9 @@ func (n Node) String() string {
 	return fmt.Sprintf("%s:%s", n.IP, n.Port)
 }
 
+var ParanoidDir string
+var MountPoint string
+
 // Node information for the current node
 var ThisNode Node
 
@@ -33,15 +36,6 @@ var DiscoveryAddr string
 
 // Nodes instance which controls all the information about other pfsd instances
 var Nodes = nodes{m: make(map[Node]bool)}
-
-var Server string
-var Port int
-
-// Common Name of the cert PFSD is using
-var CommonName string
-
-// UUID of the node PFSD is managing
-var UUID string
 
 // If true, TLS is being used in all connections to and from PFSD
 var TLSEnabled bool

--- a/pfsd/pnetclient/joincluster.go
+++ b/pfsd/pnetclient/joincluster.go
@@ -6,7 +6,6 @@ import (
 	"github.com/cpssd/paranoid/pfsd/upnp"
 	pb "github.com/cpssd/paranoid/proto/paranoidnetwork"
 	"golang.org/x/net/context"
-	"strconv"
 )
 
 //JoinCluster is used to request to join a raft cluster
@@ -19,7 +18,6 @@ func JoinCluster() error {
 	nodes := globals.Nodes.GetAll()
 	for _, node := range nodes {
 		Log.Info("Sending join cluster request to node:", node)
-		port := strconv.Itoa(globals.Port)
 
 		conn, err := Dial(node)
 		if err != nil {
@@ -31,9 +29,9 @@ func JoinCluster() error {
 
 		_, err = client.JoinCluster(context.Background(), &pb.PingRequest{
 			Ip:         ip,
-			Port:       port,
-			CommonName: globals.CommonName,
-			Uuid:       globals.UUID,
+			Port:       globals.ThisNode.Port,
+			CommonName: globals.ThisNode.CommonName,
+			Uuid:       globals.ThisNode.UUID,
 		})
 		if err != nil {
 			Log.Error("Error requesting to join cluster", node, ":", err)

--- a/pfsd/pnetclient/ping.go
+++ b/pfsd/pnetclient/ping.go
@@ -5,7 +5,6 @@ import (
 	"github.com/cpssd/paranoid/pfsd/upnp"
 	pb "github.com/cpssd/paranoid/proto/paranoidnetwork"
 	"golang.org/x/net/context"
-	"strconv"
 )
 
 func Ping() {
@@ -16,8 +15,6 @@ func Ping() {
 
 	nodes := globals.Nodes.GetAll()
 	for _, node := range nodes {
-		port := strconv.Itoa(globals.Port)
-
 		conn, err := Dial(node)
 		if err != nil {
 			Log.Error("Ping: failed to dial ", node)
@@ -28,9 +25,9 @@ func Ping() {
 
 		_, err = client.Ping(context.Background(), &pb.PingRequest{
 			Ip:         ip,
-			Port:       port,
-			CommonName: globals.CommonName,
-			Uuid:       globals.UUID,
+			Port:       globals.ThisNode.Port,
+			CommonName: globals.ThisNode.CommonName,
+			Uuid:       globals.ThisNode.UUID,
 		})
 		if err != nil {
 			Log.Error("Can't ping", node)

--- a/pfsd/pnetserver/globals.go
+++ b/pfsd/pnetserver/globals.go
@@ -9,10 +9,6 @@ import (
 
 type ParanoidServer struct{}
 
-// Path to the PFS root directory
-var ParanoidDir string
-
 var Log *logger.ParanoidLogger
 
-//Raft network server
 var RaftNetworkServer *raft.RaftNetworkServer

--- a/pfsd/signals.go
+++ b/pfsd/signals.go
@@ -3,7 +3,6 @@ package main
 import (
 	"github.com/cpssd/paranoid/pfsd/globals"
 	"github.com/cpssd/paranoid/pfsd/intercom"
-	"github.com/cpssd/paranoid/pfsd/pnetserver"
 	"github.com/cpssd/paranoid/pfsd/upnp"
 	"github.com/kardianos/osext"
 	"os"
@@ -16,7 +15,7 @@ import (
 func stopAllServices() {
 	globals.ShuttingDown = true
 	if globals.UPnPEnabled {
-		err := upnp.ClearPortMapping(globals.Port)
+		err := upnp.ClearPortMapping(globals.ThisNode.Port)
 		if err != nil {
 			log.Info("Could not clear port mapping. Error : ", err)
 		}
@@ -78,7 +77,7 @@ func handleSIGHUP() {
 func handleSIGTERM() {
 	log.Info("SIGTERM received. Exiting.")
 	stopAllServices()
-	err := os.Remove(path.Join(pnetserver.ParanoidDir, "meta", "pfsd.pid"))
+	err := os.Remove(path.Join(globals.ParanoidDir, "meta", "pfsd.pid"))
 	if err != nil {
 		log.Info("Can't remove PID file ", err)
 	}

--- a/pfsd/upnp/upnp.go
+++ b/pfsd/upnp/upnp.go
@@ -8,6 +8,7 @@ import (
 	"github.com/huin/goupnp/dcps/internetgateway1"
 	"math/rand"
 	"net"
+	"strconv"
 )
 
 var (
@@ -111,7 +112,11 @@ func AddPortMapping(internalIp string, internalPort int) (int, error) {
 	return 0, errors.New("Unable to map port")
 }
 
-func ClearPortMapping(externalPort int) error {
+func ClearPortMapping(externalPortString string) error {
+	externalPort, err := strconv.Atoi(externalPortString)
+	if err != nil {
+		return err
+	}
 	if ipPortMappedClient != nil {
 		return ipPortMappedClient.DeletePortMapping("", uint16(externalPort), "TCP")
 	}


### PR DESCRIPTION
Globals in pfsd included Ip, Port, UUID and common name in two places. pnetserver also included information that should have been in globals.go
