### PR TITLE
paranoid-cli history fix

### DIFF
--- a/paranoid-cli/commands/historycmd.go
+++ b/paranoid-cli/commands/historycmd.go
@@ -30,7 +30,7 @@ func History(c *cli.Context) {
 	givenString := args[0]
 	var target string
 	if fileSystemExists(givenString) {
-		target = path.Join(usr.HomeDir, ".pfs", givenString, "meta", "activity_logs")
+		target = path.Join(usr.HomeDir, ".pfs", givenString, "meta", "raft", "raft_logs")
 	} else {
 		target = givenString
 	}


### PR DESCRIPTION
The folder raft logs were stored in was changed. 
