### PR TITLE
Change permissions to be stored in inodes

### DIFF
--- a/libpfs/commands/accesscmd.go
+++ b/libpfs/commands/accesscmd.go
@@ -2,9 +2,8 @@ package commands
 
 import (
 	"errors"
+	"fmt"
 	"github.com/cpssd/paranoid/libpfs/returncodes"
-	"path"
-	"syscall"
 )
 
 //AccessCommand is used by fuse to check if it has access to a given file.
@@ -43,9 +42,9 @@ func AccessCommand(paranoidDirectory, filePath string, mode uint32) (returnCode 
 
 	inodeName := string(inodeNameBytes)
 
-	err = syscall.Access(path.Join(paranoidDirectory, "contents", inodeName), mode)
+	code, err = canAccessFile(paranoidDirectory, inodeName, mode)
 	if err != nil {
-		return returncodes.EACCES, errors.New("could not access " + filePath)
+		return code, fmt.Errorf("unable to access %s: %s", filePath, err)
 	}
 	return returncodes.OK, nil
 }

--- a/libpfs/commands/chmodcmd.go
+++ b/libpfs/commands/chmodcmd.go
@@ -1,13 +1,17 @@
 package commands
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"github.com/cpssd/paranoid/libpfs/returncodes"
+	"io/ioutil"
 	"os"
 	"path"
 	"syscall"
 )
+
+const PERM_MASK = 0777
 
 //ChmodCommand is used to change the permissions of a file.
 func ChmodCommand(paranoidDirectory, filePath string, perms os.FileMode) (returnCode int, returnError error) {
@@ -48,22 +52,35 @@ func ChmodCommand(paranoidDirectory, filePath string, perms os.FileMode) (return
 	}
 	inodeName := string(inodeNameBytes)
 
-	err = syscall.Access(path.Join(paranoidDirectory, "contents", inodeName), getAccessMode(syscall.O_WRONLY))
+	code, err = canAccessFile(paranoidDirectory, inodeName, getAccessMode(syscall.O_WRONLY))
 	if err != nil {
-		return returncodes.EACCES, errors.New("unable to access " + filePath)
+		return code, fmt.Errorf("unable to access %s: %s", filePath, err)
 	}
 
 	Log.Verbosef("chmod : changing permissions of "+inodeName+" to", perms)
 
-	contentsFile, err := os.OpenFile(path.Join(paranoidDirectory, "contents", inodeName), os.O_WRONLY, 0777)
+	inodePath := path.Join(paranoidDirectory, "inodes", inodeName)
+	inodeContents, err := ioutil.ReadFile(inodePath)
 	if err != nil {
-		return returncodes.EUNEXPECTED, fmt.Errorf("unexpected error attempting to open file:", err)
+		return returncodes.EUNEXPECTED, fmt.Errorf("error reading inode: %s", err)
 	}
-	defer contentsFile.Close()
 
-	err = contentsFile.Chmod(perms)
+	nodeData := &inode{}
+	err = json.Unmarshal(inodeContents, &nodeData)
 	if err != nil {
-		return returncodes.EUNEXPECTED, fmt.Errorf("unexpected error attempting to change file permissions:", err)
+		return returncodes.EUNEXPECTED, fmt.Errorf("error unmarshaling inode data: %s", err)
+	}
+
+	nodeData.Mode = (nodeData.Mode &^ PERM_MASK) | perms
+
+	jsonData, err := json.Marshal(nodeData)
+	if err != nil {
+		return returncodes.EUNEXPECTED, fmt.Errorf("error marshalling json:", err)
+	}
+
+	err = ioutil.WriteFile(inodePath, jsonData, 0600)
+	if err != nil {
+		return returncodes.EUNEXPECTED, fmt.Errorf("error writing inodes file:", err)
 	}
 
 	return returncodes.OK, nil

--- a/libpfs/commands/creatcmd.go
+++ b/libpfs/commands/creatcmd.go
@@ -54,6 +54,7 @@ func CreatCommand(paranoidDirectory, filePath string, perms os.FileMode) (return
 	}
 
 	nodeData := &inode{
+		Mode:  perms,
 		Inode: uuidstring,
 		Count: 1}
 	jsonData, err := json.Marshal(nodeData)
@@ -71,11 +72,6 @@ func CreatCommand(paranoidDirectory, filePath string, perms os.FileMode) (return
 		return returncodes.EUNEXPECTED, fmt.Errorf("error creating contents file:", err)
 	}
 	defer contentsFile.Close()
-
-	err = contentsFile.Chmod(perms)
-	if err != nil {
-		return returncodes.EUNEXPECTED, fmt.Errorf("error changing file permissions:", err)
-	}
 
 	return returncodes.OK, nil
 }

--- a/libpfs/commands/mkdircmd.go
+++ b/libpfs/commands/mkdircmd.go
@@ -7,6 +7,7 @@ import (
 	"github.com/cpssd/paranoid/libpfs/returncodes"
 	"os"
 	"path"
+	"syscall"
 )
 
 // MkdirCommand is called when making a paranoidDirectory
@@ -80,6 +81,7 @@ func MkdirCommand(paranoidDirectory, dirPath string, mode os.FileMode) (returnCo
 	defer inodeFile.Close()
 
 	nodeData := &inode{
+		Mode:  mode | syscall.S_IFDIR,
 		Inode: inodeString,
 		Count: 1}
 	jsonData, err := json.Marshal(nodeData)

--- a/libpfs/commands/readcmd.go
+++ b/libpfs/commands/readcmd.go
@@ -57,9 +57,9 @@ func ReadCommand(paranoidDirectory, filePath string, offset, length int64) (retu
 	}
 	inodeFileName := string(inodeBytes)
 
-	err = syscall.Access(path.Join(paranoidDirectory, "contents", inodeFileName), getAccessMode(syscall.O_RDONLY))
+	code, err = canAccessFile(paranoidDirectory, inodeFileName, getAccessMode(syscall.O_RDONLY))
 	if err != nil {
-		return returncodes.EACCES, errors.New("could not access file " + filePath), nil
+		return code, fmt.Errorf("unable to access %s: %s", filePath, err), nil
 	}
 
 	err = getFileLock(paranoidDirectory, inodeFileName, sharedLock)

--- a/libpfs/commands/renamecmd.go
+++ b/libpfs/commands/renamecmd.go
@@ -6,7 +6,6 @@ import (
 	"github.com/cpssd/paranoid/libpfs/returncodes"
 	"io/ioutil"
 	"os"
-	"path"
 	"syscall"
 )
 
@@ -68,9 +67,9 @@ func RenameCommand(paranoidDirectory, oldFilePath, newFilePath string) (returnCo
 		return code, err
 	}
 
-	err = syscall.Access(path.Join(paranoidDirectory, "contents", string(inodeBytes)), getAccessMode(syscall.O_WRONLY))
+	code, err = canAccessFile(paranoidDirectory, string(inodeBytes), getAccessMode(syscall.O_WRONLY))
 	if err != nil {
-		return returncodes.EACCES, errors.New("can not access " + oldFilePath)
+		return code, fmt.Errorf("unable to access %s: %s", oldFilePath, err)
 	}
 
 	err = os.Rename(oldFileParanoidPath, newFileParanoidPath)

--- a/libpfs/commands/rmdircmd.go
+++ b/libpfs/commands/rmdircmd.go
@@ -58,9 +58,9 @@ func RmdirCommand(paranoidDirectory, dirPath string) (returnCode int, returnErro
 
 	inodeString := string(inodeBytes)
 
-	err = syscall.Access(path.Join(paranoidDirectory, "contents", inodeString), getAccessMode(syscall.O_WRONLY))
+	code, err = canAccessFile(paranoidDirectory, inodeString, getAccessMode(syscall.O_WRONLY))
 	if err != nil {
-		return returncodes.EACCES, errors.New("could not access " + dirPath)
+		return code, fmt.Errorf("unable to access %s: %s", dirPath, err)
 	}
 
 	inodeFileToDelete := path.Join(paranoidDirectory, "inodes", inodeString)

--- a/libpfs/commands/statcmd.go
+++ b/libpfs/commands/statcmd.go
@@ -63,13 +63,9 @@ func StatCommand(paranoidDirectory, filePath string) (returnCode int, returnErro
 	stat := fi.Sys().(*syscall.Stat_t)
 	atime := time.Unix(int64(stat.Atim.Sec), int64(stat.Atim.Nsec))
 	ctime := time.Unix(int64(stat.Ctim.Sec), int64(stat.Ctim.Nsec))
-
-	var mode os.FileMode
-	switch namePathType {
-	case typeDir:
-		mode = os.FileMode(syscall.S_IFDIR | fi.Mode().Perm())
-	default:
-		mode = os.FileMode(stat.Mode)
+	mode, err := getFileMode(paranoidDirectory, inodeName)
+	if err != nil {
+		return returncodes.EUNEXPECTED, fmt.Errorf("error getting filemode:", err), statInfo{}
 	}
 
 	statData := &statInfo{

--- a/libpfs/commands/truncatecmd.go
+++ b/libpfs/commands/truncatecmd.go
@@ -51,9 +51,9 @@ func TruncateCommand(paranoidDirectory, filePath string, length int64) (returnCo
 	}
 	inodeName := string(fileInodeBytes)
 
-	err = syscall.Access(path.Join(paranoidDirectory, "contents", inodeName), getAccessMode(syscall.O_WRONLY))
+	code, err = canAccessFile(paranoidDirectory, inodeName, getAccessMode(syscall.O_WRONLY))
 	if err != nil {
-		return returncodes.EACCES, errors.New("could not access " + filePath)
+		return code, fmt.Errorf("unable to access %s: %s", filePath, err)
 	}
 
 	err = getFileLock(paranoidDirectory, inodeName, exclusiveLock)

--- a/libpfs/commands/unlinkcmd.go
+++ b/libpfs/commands/unlinkcmd.go
@@ -51,9 +51,9 @@ func UnlinkCommand(paranoidDirectory, filePath string) (returnCode int, returnEr
 	}
 
 	//checking if we have access to the file.
-	err = syscall.Access(path.Join(paranoidDirectory, "contents", string(inodeBytes)), getAccessMode(syscall.O_WRONLY))
+	code, err = canAccessFile(paranoidDirectory, string(inodeBytes), getAccessMode(syscall.O_WRONLY))
 	if err != nil {
-		return returncodes.EACCES, errors.New("could not access " + filePath)
+		return code, fmt.Errorf("unable to access %s: %s", filePath, err)
 	}
 
 	// removing filename

--- a/libpfs/commands/utimescmd.go
+++ b/libpfs/commands/utimescmd.go
@@ -45,9 +45,9 @@ func UtimesCommand(paranoidDirectory, filePath string, atime, mtime *time.Time) 
 	}
 	inodeName := string(fileInodeBytes)
 
-	err = syscall.Access(path.Join(paranoidDirectory, "contents", inodeName), getAccessMode(syscall.O_WRONLY))
+	code, err = canAccessFile(paranoidDirectory, inodeName, getAccessMode(syscall.O_WRONLY))
 	if err != nil {
-		return returncodes.EACCES, errors.New("could not access " + filePath)
+		return code, fmt.Errorf("unable to access %s: %s", filePath, err)
 	}
 
 	err = getFileLock(paranoidDirectory, inodeName, exclusiveLock)

--- a/libpfs/commands/writecmd.go
+++ b/libpfs/commands/writecmd.go
@@ -53,9 +53,9 @@ func WriteCommand(paranoidDirectory, filePath string, offset, length int64, data
 	}
 	inodeName := string(fileInodeBytes)
 
-	err = syscall.Access(path.Join(paranoidDirectory, "contents", inodeName), getAccessMode(syscall.O_WRONLY))
+	code, err = canAccessFile(paranoidDirectory, inodeName, getAccessMode(syscall.O_WRONLY))
 	if err != nil {
-		return returncodes.EACCES, errors.New("could not access " + filePath), 0
+		return code, fmt.Errorf("unable to access %s: %s", filePath, err), 0
 	}
 
 	err = getFileLock(paranoidDirectory, inodeName, exclusiveLock)


### PR DESCRIPTION
For encryption, the mode of the contents file can not a direct representation of the permissions, as reading and writing needs to be done to write a file or truncate a file.
