### PR TITLE
Fix not outputting pool name

### DIFF
--- a/paranoid-cli/commands/initcmd.go
+++ b/paranoid-cli/commands/initcmd.go
@@ -81,9 +81,10 @@ func doInit(pfsname, pool, cert, key string, unsecure bool) {
 	}
 	err = ioutil.WriteFile(path.Join(directory, "meta", "pool"), []byte(pool), 0600)
 	if err != nil {
-		fmt.Println("FATAL: Cannot save pool information:")
+		fmt.Println("FATAL: Cannot save pool information")
 		Log.Fatal("cannot save pool information:", err)
 	}
+	fmt.Println("Using pool name", pool)
 	Log.Infof("Using pool name %s", pool)
 
 	if unsecure {


### PR DESCRIPTION
When Log was changed to log to a file, this was missed.
