### PR TITLE
Better read and write test.

### DIFF
--- a/libpfs/commands/commands_test.go
+++ b/libpfs/commands/commands_test.go
@@ -78,12 +78,12 @@ func TestComplexCommandUsage(t *testing.T) {
 		t.Error("error creating test file:", err)
 	}
 
-	code, err, n := WriteCommand(testDirectory, "test.txt", -1, -1, []byte("START"))
+	code, err, bytesWritten := WriteCommand(testDirectory, "test.txt", -1, -1, []byte("START"))
 	if code != returncodes.OK {
 		t.Error("Write did not return OK. Actual:", code, " Error:", err)
 	}
-	if n != len([]byte("START")) {
-		t.Error("Write did not return correct number of bytes Actual:", n, "Expected:", len([]byte("START")))
+	if bytesWritten != len([]byte("START")) {
+		t.Error("Write did not return correct number of bytes Actual:", bytesWritten, "Expected:", len([]byte("START")))
 	}
 
 	code, err, returnData := ReadCommand(testDirectory, "test.txt", 2, 2)
@@ -95,12 +95,12 @@ func TestComplexCommandUsage(t *testing.T) {
 		t.Error("Output from partial read does not match ", string(returnData))
 	}
 
-	code, err, n = WriteCommand(testDirectory, "test.txt", 5, -1, []byte("END"))
+	code, err, bytesWritten = WriteCommand(testDirectory, "test.txt", 5, -1, []byte("END"))
 	if code != returncodes.OK {
 		t.Error("Write did not return OK Actual: ", code, " Error:", err)
 	}
-	if n != len([]byte("END")) {
-		t.Error("Write did not return correct number of bytes Actual:", n, "Expected:", len([]byte("END")))
+	if bytesWritten != len([]byte("END")) {
+		t.Error("Write did not return correct number of bytes Actual:", bytesWritten, "Expected:", len([]byte("END")))
 	}
 
 	code, err, returnData = ReadCommand(testDirectory, "test.txt", -1, -1)
@@ -278,12 +278,12 @@ func TestLinkCommand(t *testing.T) {
 		t.Error("Readdir got incorrect results")
 	}
 
-	code, err, n := WriteCommand(testDirectory, "test2.txt", -1, -1, []byte("hellotest"))
+	code, err, bytesWritten := WriteCommand(testDirectory, "test2.txt", -1, -1, []byte("hellotest"))
 	if code != returncodes.OK {
 		t.Error("Write did not return OK. Actual:", code, " Error:", err)
 	}
-	if n != len([]byte("hellotest")) {
-		t.Error("Write did not return correct number of bytes Actual:", n, "Expected:", len([]byte("hellotest")))
+	if bytesWritten != len([]byte("hellotest")) {
+		t.Error("Write did not return correct number of bytes Actual:", bytesWritten, "Expected:", len([]byte("hellotest")))
 	}
 
 	code, err, data := ReadCommand(testDirectory, "test.txt", -1, -1)
@@ -389,12 +389,12 @@ func TestTruncate(t *testing.T) {
 		t.Error("error creating test file:", err)
 	}
 
-	code, err, n := WriteCommand(testDirectory, "test.txt", -1, -1, []byte("HI!!!!!"))
+	code, err, bytesWritten := WriteCommand(testDirectory, "test.txt", -1, -1, []byte("HI!!!!!"))
 	if code != returncodes.OK {
 		t.Error("Write command failed! : ", err)
 	}
-	if n != len([]byte("HI!!!!!")) {
-		t.Error("Write did not return correct number of bytes Actual:", n, "Expected:", len([]byte("HI!!!!!")))
+	if bytesWritten != len([]byte("HI!!!!!")) {
+		t.Error("Write did not return correct number of bytes Actual:", bytesWritten, "Expected:", len([]byte("HI!!!!!")))
 	}
 
 	code, err = TruncateCommand(testDirectory, "test.txt", 3)
@@ -496,12 +496,12 @@ func TestComplexDirectoryUsage(t *testing.T) {
 
 	// writing and reading from file within directory
 	toWrite := []byte("https://www.google.com/")
-	code, err, n := WriteCommand(testDirectory, "documents/important_links.txt", -1, -1, toWrite)
+	code, err, bytesWritten := WriteCommand(testDirectory, "documents/important_links.txt", -1, -1, toWrite)
 	if code != returncodes.OK {
 		t.Error("Write did not return OK. Actual:", code, " Error:", err)
 	}
-	if n != len(toWrite) {
-		t.Error("Write did not return correct number of bytes Actual:", n, "Expected:", len(toWrite))
+	if bytesWritten != len(toWrite) {
+		t.Error("Write did not return correct number of bytes Actual:", bytesWritten, "Expected:", len(toWrite))
 	}
 
 	code, err, data := ReadCommand(testDirectory, "documents/important_links.txt", -1, -1)
@@ -623,12 +623,12 @@ func TestComplexReadWrite(t *testing.T) {
 			data[j] = byte(randN(26) + int('A'))
 		}
 
-		code, err, n := WriteCommand(testDirectory, "test.txt", int64(writeStart), int64(writeLength), data)
+		code, err, bytesWritten := WriteCommand(testDirectory, "test.txt", int64(writeStart), int64(writeLength), data)
 		if code != returncodes.OK {
 			t.Error("Write did not return OK. Actual:", code, " Error:", err)
 		}
-		if n != len(data) {
-			t.Error("Write did not return correct number of bytes Actual:", n, "Expected:", len(data))
+		if bytesWritten != len(data) {
+			t.Error("Write did not return correct number of bytes Actual:", bytesWritten, "Expected:", len(data))
 		}
 
 		if writeStart+writeLength > fileLength {


### PR DESCRIPTION
Encryption development showed that the current libpfs read and write tests are not very extensive. 
This test fails feature/voy/encryption while previous read and write tests do not. 
Also include checking the number of bytes wrote returned from all write calls. 

```
--- FAIL: TestComplexReadWrite (0.01s)
    commands_test.go:628: Output does not match 
         Expected: KLYROZZNOGIASQEWXENPQBXVEOTPBCMPBWJFMLGMLGYOQLADKHNJKBKAHRRTXGLCFDHYSEQAPYNIEBWWDRVOCRZSAJOQDVUBPOZDRTSTRCGBYIAZDGEBFLZMSSXLMVZAYSCXIGSEISJGCGUYOCWVAMVMVSZABWGGTDLGHRWSLMDTUZPNABABMCKEJZDNZPOGHYKDOOOLQYUVBRUGRTBZRINQZNXYCEEQLDBJEVXHBBMBOSPSBLKSISRXLHTIXYZRYUKNSSYNQBHAQDDROUJXLZJKAXSILRCCRQDOWRMQHPSXZWOMOLHYGGLNBFNUFEDSIBDAMCBOJSLCXYNAJOVHHDOQDVPGFPFMBZISBGUGR
         Actual: QVBRLAIPSQEWXENPQVBRLAIPYAPBCMPQVBRLAIPYAPFMLGPFMBZISBGUGRKHNJKBKAHRRTXGLCWWDRVOCRZSAJOQDVUBPOZDRTSTLZMSSXLMVZAYSCXIGSEISJGCGUYOCWSZABWGGTDLGHRWSLCOXGHQSYRDVCVVQVBRLAIPYANZPOGHYKDOOOLXEAELQYUVBRPFMBZISBGUGRXHBBMBOSPSBLKSISRXLHTIXYZRYUKNSSYNQBHAQDDROUJXLZJKAXSILRNGMDLHYGGLNBFNUFEDSIBDAMCBOJSLCXYNAJOVHHDOQDVPGFPFMB
```
