### PR TITLE
Remove unnecessary permission checks

### DIFF
--- a/libpfs/commands/commands_test.go
+++ b/libpfs/commands/commands_test.go
@@ -185,11 +185,6 @@ func TestFilePermissionsCommands(t *testing.T) {
 		t.Error("Incorrect file permissions = ", statIn.Mode.Perm())
 	}
 
-	code, err, _ = WriteCommand(testDirectory, "test.txt", -1, -1, []byte("yay"))
-	if code != returncodes.EACCES {
-		t.Error("Should not be able to write file ", statIn.Mode.Perm())
-	}
-
 	code, err = AccessCommand(testDirectory, "test.txt", 4)
 	if code != returncodes.OK {
 		t.Error("Access command did not return OK. Actual:", code, " Error:", err)

--- a/libpfs/commands/readcmd.go
+++ b/libpfs/commands/readcmd.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"path"
 	"strconv"
-	"syscall"
 )
 
 //ReadCommand reads data from a file
@@ -56,11 +55,6 @@ func ReadCommand(paranoidDirectory, filePath string, offset, length int64) (retu
 		return code, err, nil
 	}
 	inodeFileName := string(inodeBytes)
-
-	code, err = canAccessFile(paranoidDirectory, inodeFileName, getAccessMode(syscall.O_RDONLY))
-	if err != nil {
-		return code, fmt.Errorf("unable to access %s: %s", filePath, err), nil
-	}
 
 	err = getFileLock(paranoidDirectory, inodeFileName, SharedLock)
 	if err != nil {

--- a/libpfs/commands/renamecmd.go
+++ b/libpfs/commands/renamecmd.go
@@ -6,7 +6,6 @@ import (
 	"github.com/cpssd/paranoid/libpfs/returncodes"
 	"io/ioutil"
 	"os"
-	"syscall"
 )
 
 // RenameCommand is called when renaming a file
@@ -60,16 +59,6 @@ func RenameCommand(paranoidDirectory, oldFilePath, newFilePath string) (returnCo
 				return returncodes.EEXIST, errors.New(newFilePath + " already exists")
 			}
 		}
-	}
-
-	inodeBytes, code, err := getFileInode(oldFileParanoidPath)
-	if code != returncodes.OK || err != nil {
-		return code, err
-	}
-
-	code, err = canAccessFile(paranoidDirectory, string(inodeBytes), getAccessMode(syscall.O_WRONLY))
-	if err != nil {
-		return code, fmt.Errorf("unable to access %s: %s", oldFilePath, err)
 	}
 
 	err = os.Rename(oldFileParanoidPath, newFileParanoidPath)

--- a/libpfs/commands/truncatecmd.go
+++ b/libpfs/commands/truncatecmd.go
@@ -7,7 +7,6 @@ import (
 	"github.com/cpssd/paranoid/libpfs/returncodes"
 	"os"
 	"path"
-	"syscall"
 )
 
 //TruncateCommand reduces the file given to the new length
@@ -51,11 +50,6 @@ func TruncateCommand(paranoidDirectory, filePath string, length int64) (returnCo
 		return code, err
 	}
 	inodeName := string(fileInodeBytes)
-
-	code, err = canAccessFile(paranoidDirectory, inodeName, getAccessMode(syscall.O_WRONLY))
-	if err != nil {
-		return code, fmt.Errorf("unable to access %s: %s", filePath, err)
-	}
 
 	err = getFileLock(paranoidDirectory, inodeName, ExclusiveLock)
 	if err != nil {

--- a/libpfs/commands/unlinkcmd.go
+++ b/libpfs/commands/unlinkcmd.go
@@ -8,7 +8,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
-	"syscall"
 )
 
 // UnlinkCommand removes a filename link from an inode.
@@ -48,12 +47,6 @@ func UnlinkCommand(paranoidDirectory, filePath string) (returnCode returncodes.C
 	inodeBytes, code, err := getFileInode(fileParanoidPath)
 	if code != returncodes.OK {
 		return code, err
-	}
-
-	//checking if we have access to the file.
-	code, err = canAccessFile(paranoidDirectory, string(inodeBytes), getAccessMode(syscall.O_WRONLY))
-	if err != nil {
-		return code, fmt.Errorf("unable to access %s: %s", filePath, err)
 	}
 
 	// removing filename

--- a/libpfs/commands/utimescmd.go
+++ b/libpfs/commands/utimescmd.go
@@ -45,11 +45,6 @@ func UtimesCommand(paranoidDirectory, filePath string, atime, mtime *time.Time) 
 	}
 	inodeName := string(fileInodeBytes)
 
-	code, err = canAccessFile(paranoidDirectory, inodeName, getAccessMode(syscall.O_WRONLY))
-	if err != nil {
-		return code, fmt.Errorf("unable to access %s: %s", filePath, err)
-	}
-
 	err = getFileLock(paranoidDirectory, inodeName, ExclusiveLock)
 	if err != nil {
 		return returncodes.EUNEXPECTED, err

--- a/libpfs/commands/writecmd.go
+++ b/libpfs/commands/writecmd.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"os"
 	"path"
-	"syscall"
 )
 
 //WriteCommand writes data to the given file
@@ -53,11 +52,6 @@ func WriteCommand(paranoidDirectory, filePath string, offset, length int64, data
 		return code, err, 0
 	}
 	inodeName := string(fileInodeBytes)
-
-	code, err = canAccessFile(paranoidDirectory, inodeName, getAccessMode(syscall.O_WRONLY))
-	if err != nil {
-		return code, fmt.Errorf("unable to access %s: %s", filePath, err), 0
-	}
 
 	err = getFileLock(paranoidDirectory, inodeName, ExclusiveLock)
 	if err != nil {


### PR DESCRIPTION
These permission checks are unnecessary because fuse performs access checks before these calls, and once a write file descriptor has been given all writes should succeed to it.

Closes #294
