### PR TITLE
Fix issue with status on pfsd with networking disabled

### DIFF
--- a/paranoid-cli/commands/initcmd.go
+++ b/paranoid-cli/commands/initcmd.go
@@ -106,6 +106,10 @@ func doInit(pfsname, pool, cert, key string, unsecure, unencrypted, networkoff b
 		Log.Fatal("cannot save file system information:", err)
 	}
 
+	if networkoff {
+		return
+	}
+
 	if unsecure {
 		fmt.Println("--unsecure specified. PFSD will not use TLS for its communication.")
 		return

--- a/paranoid-cli/commands/mountcmd.go
+++ b/paranoid-cli/commands/mountcmd.go
@@ -176,7 +176,6 @@ func doMount(c *cli.Context, args []string) {
 		if c.GlobalBool("verbose") {
 			pfsdFlags = append(pfsdFlags, "-v")
 		}
-		pfsdFlags = append(pfsdFlags, "--no_networking")
 		cmd := exec.Command("pfsd", append(pfsdFlags, pfsdArgs...)...)
 		err = cmd.Start()
 		if err != nil {

--- a/paranoid-cli/commands/statuscmd.go
+++ b/paranoid-cli/commands/statuscmd.go
@@ -77,6 +77,8 @@ func printStatusInfo(pfsName string, info intercom.StatusResponse) {
 	fmt.Printf("\nFilesystem Name:\t%s\n", pfsName)
 	fmt.Printf("Uptime:\t\t\t%s\n", info.Uptime.String())
 	fmt.Printf("Raft Status:\t\t%s\n", info.Status)
-	fmt.Printf("TLS Enabled:\t\t%t\n", info.TLSActive)
-	fmt.Printf("Port:\t\t\t%d\n", info.Port)
+	if info.Status != intercom.STATUS_NETWORKOFF {
+		fmt.Printf("TLS Enabled:\t\t%t\n", info.TLSActive)
+		fmt.Printf("Port:\t\t\t%d\n", info.Port)
+	}
 }

--- a/pfsd/globals/globals.go
+++ b/pfsd/globals/globals.go
@@ -56,6 +56,8 @@ var DiscoveryAddr string
 // Nodes instance which controls all the information about other pfsd instances
 var Nodes = nodes{m: make(map[Node]bool)}
 
+var NetworkOff bool
+
 // If true, TLS is being used in all connections to and from PFSD
 var TLSEnabled bool
 

--- a/pfsd/intercom/server.go
+++ b/pfsd/intercom/server.go
@@ -12,6 +12,10 @@ import (
 	"time"
 )
 
+const (
+	STATUS_NETWORKOFF string = "Networking disabled"
+)
+
 type IntercomServer struct{}
 type EmptyMessage struct{}
 
@@ -33,6 +37,12 @@ func (s *IntercomServer) ConfirmUp(req *EmptyMessage, resp *EmptyMessage) error 
 
 // Provides health data for the current node.
 func (s *IntercomServer) Status(req *EmptyMessage, resp *StatusResponse) error {
+	if globals.NetworkOff {
+		resp.Uptime = time.Since(globals.BootTime)
+		resp.Status = STATUS_NETWORKOFF
+		return nil
+	}
+
 	thisport, err := strconv.Atoi(globals.ThisNode.Port)
 	if err != nil {
 		Log.Error("Could not convert globals.ThisNode.Port to int.")

--- a/pfsd/main.go
+++ b/pfsd/main.go
@@ -36,7 +36,6 @@ var (
 
 	certFile   = flag.String("cert", "", "TLS certificate file - if empty connection will be unencrypted")
 	keyFile    = flag.String("key", "", "TLS key file - if empty connection will be unencrypted")
-	noNetwork  = flag.Bool("no_networking", false, "Do not perform any networking")
 	skipVerify = flag.Bool("skip_verification", false,
 		"skip verification of TLS certificate chain and hostname - not recommended unless using self-signed certs")
 	verbose = flag.Bool("v", false, "Use verbose logging")
@@ -152,6 +151,7 @@ func getFileSystemAttributes() {
 	}
 
 	globals.Encrypted = attributes.Encrypted
+	globals.NetworkOff = attributes.NetworkOff
 	encryption.Encrypted = attributes.Encrypted
 
 	if attributes.Encrypted {
@@ -235,7 +235,7 @@ func main() {
 		globals.TLSEnabled = false
 	}
 
-	if !*noNetwork {
+	if !globals.NetworkOff {
 		discoveryPort, err := strconv.Atoi(flag.Arg(3))
 		if err != nil || discoveryPort < 1 || discoveryPort > 65535 {
 			log.Fatal("Discovery port must be a number between 1 and 65535, inclusive.")

--- a/pfsd/signals.go
+++ b/pfsd/signals.go
@@ -23,7 +23,7 @@ func stopAllServices() {
 	// Save all KeyPieces to disk, to ensure we haven't missed any so far.
 	globals.HeldKeyPieces.SaveToDisk()
 
-	if !*noNetwork {
+	if !globals.NetworkOff {
 		close(globals.RaftNetworkServer.Quit)
 		srv.Stop()
 		globals.RaftNetworkServer.Wait.Wait()


### PR DESCRIPTION
Networking off also should not be passed as a flag anymore, because it is used in the attributes json file anyway. 
Closes #375
