### PR TITLE
Fix possibility for raft configuration not to update from snapshot

### DIFF
--- a/raft/snapshot.go
+++ b/raft/snapshot.go
@@ -390,14 +390,16 @@ func (s *RaftNetworkServer) RevertToSnapshot(snapshotPath string) error {
 		return fmt.Errorf("error reverting to snapshot: %s", err)
 	}
 
-	err = os.Rename(path.Join(s.State.pfsDirectory, PersistentConfigurationFileName), path.Join(s.raftInfoDirectory, PersistentConfigurationFileName))
+	err = s.State.Configuration.UpdateFromConfigurationFile(
+		path.Join(s.State.pfsDirectory, PersistentConfigurationFileName),
+		snapshotMeta.LastIncludedIndex)
 	if err != nil {
 		return fmt.Errorf("error reverting to snapshot: %s", err)
 	}
 
-	err = s.State.Configuration.UpdateFromConfigurationFile(path.Join(s.raftInfoDirectory, PersistentConfigurationFileName), snapshotMeta.LastIncludedIndex)
+	err = os.Remove(path.Join(s.State.pfsDirectory, PersistentConfigurationFileName))
 	if err != nil {
-		return fmt.Errorf("error reverting to snapshot: %s", err)
+		Log.Warn("Unable to delete snapshot configuration file")
 	}
 
 	currentSnapshot := path.Join(s.raftInfoDirectory, SnapshotDirectory, CurrentSnapshotDirectory)


### PR DESCRIPTION
Previously the configuration file unpacked from the snapshot was renamed to where the current configuration file is stored, however this means that if a operation was happening on the configuration at the same time, it could overwrite this file.
